### PR TITLE
Only include sysctl if PTHREADS are being used.

### DIFF
--- a/src/pHash.h
+++ b/src/pHash.h
@@ -57,7 +57,9 @@ using namespace cimg_library;
 
 #ifndef __GLIBC__
 #include <sys/param.h>
+#ifdef HAVE_PTHREAD
 #include <sys/sysctl.h>
+#endif
 #endif
 
 using namespace std;


### PR DESCRIPTION
This fixes an import error when compiling for Android/ARM
without PTHREADS.
