### PR TITLE
For images with all pixels of the same RGB value

### DIFF
--- a/src/pHash.cpp
+++ b/src/pHash.cpp
@@ -394,7 +394,7 @@ int ph_dct_imagehash(const char* file,ulong64 &hash){
     hash = 0x0000000000000000;
     for (int i=0;i< 64;i++){
 	float current = subsec(i);
-        if (current > median)
+        if (current >= median)
 	    hash |= one;
 	one = one << 1;
     }


### PR DESCRIPTION
If you have an image with all pixels having the same value. Example: https://scontent-iad3-1.cdninstagram.com/vp/d84eb53f5346d7bf1f8c8c817833e278/5B754B0D/t51.2885-15/e35/30084946_877853032375805_5440853794499854336_n.jpg
The condition (current > median) is never true and hence returns 0 hash. current >= median solves this problem.