### PR TITLE
proper pthread return value

### DIFF
--- a/src/pHash.cpp
+++ b/src/pHash.cpp
@@ -407,17 +407,17 @@ int ph_dct_imagehash(const char* file,ulong64 &hash){
 #ifdef HAVE_PTHREAD
 void *ph_image_thread(void *p)
 {
-        slice *s = (slice *)p;
-        for(int i = 0; i < s->n; ++i)
-        {
-                DP *dp = (DP *)s->hash_p[i];
+	slice *s = (slice *)p;
+	for(int i = 0; i < s->n; ++i)
+	{
+		DP *dp = (DP *)s->hash_p[i];
 		ulong64 hash;
 		int ret = ph_dct_imagehash(dp->id, hash);
-                dp->hash = (ulong64*)malloc(sizeof(hash));
+		dp->hash = (ulong64*)malloc(sizeof(hash));
 		memcpy(dp->hash, &hash, sizeof(hash));
-                dp->hash_length = 1;
-        }
-        return NULL;
+		dp->hash_length = 1;
+	}
+	return NULL;
 }
 
 DP** ph_dct_image_hashes(char *files[], int count, int threads)

--- a/src/pHash.cpp
+++ b/src/pHash.cpp
@@ -417,6 +417,7 @@ void *ph_image_thread(void *p)
 		memcpy(dp->hash, &hash, sizeof(hash));
                 dp->hash_length = 1;
         }
+        return NULL;
 }
 
 DP** ph_dct_image_hashes(char *files[], int count, int threads)


### PR DESCRIPTION
*pthread_create(3)* states that the ways for a pthread to exit includes:

> It returns from start_routine().  This is equivalent to calling pthread_exit(3) with the value supplied in the return statement.

This "retval" is a void pointer which can be anything.
In this case, since all threads are always joined with a parameter of NULL for the `void**` to store the retval this isn't really relevant for providing a meaningful return value.
However a `void*` function must return a `void*`, otherwise compilers will complain:

> pHash.cpp:416:1: warning: no return statement in function returning non-void [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wreturn-type-Wreturn-type8;;]

Therefore returning NULL seems reasonable.
As for the choice of NULL vs. nullptr or any other value, NULL is already widely used in the file.

Long story short: this fixes a compiler warning/error.

---

Other than that I fixed the indents on that function because it doesn't follow the same spacing as the rest of the file and therefore either that code or all other code in the file looked scuffed in any interface/editor. I can drop that commit if needed (it has a commit message with some context).